### PR TITLE
Update podcasts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,16 @@ this protocol is essential for every application security professional.
 
 ##### Continuous learning
 
-There are fun ways to stay on top of security news. We recommend the following
-podcasts, because they are not boring and are quite motivational:
+###### Podcasts
 
-1.  [Security Weekly](https://securityweekly.com/shows) - really great guys who
-    now have grown into a number of separate shows that we recommend subscribing
-    to all of them. Lots of extremely useful info and fun.
+Listening to podcasts is a great way to stay on top of any updates in the
+world of information security. We recommend
+[**Security Weekly**](https://securityweekly.com/shows) shows - really great guys
+who now have grown their original podcast, "Paul's Security Weekly", into a
+number of shows covering different topics, and we recommend subscribing to all
+of them. Lots of extremely useful info and fun. Absolutely not boring and very
+motivational. Authors of this document are highly influenced by the Security
+Weekly Crew and their shows.
 
 #### Practice
 


### PR DESCRIPTION
Let's face it, after a couple of years searching for alternatives, it's clear that Security Weekly sets a very high bar, and I can't really recommend someone else. Reasons (besides purely personal):
* very consistent updates - every week. unlike others, they don't disappear for months or discontinue
* awesome numerous shows and news

I am pretty sure Paul commented in one of his weekly shows something negative about security guys that have a 'kh' sound in their name (e.g. Mikhail) - you can't find that anywhere else!
